### PR TITLE
Fix JSON indentation

### DIFF
--- a/response.go
+++ b/response.go
@@ -143,7 +143,7 @@ func (r *Response) WriteAsJson(value interface{}) error {
 		return nil
 	}
 	if PrettyPrintResponses {
-		output, err = json.MarshalIndent(value, " ", " ")
+		output, err = json.MarshalIndent(value, "", "  ")
 		output = append(output, '\n')
 	} else {
 		output, err = json.Marshal(value)

--- a/response.go
+++ b/response.go
@@ -112,7 +112,7 @@ func (r *Response) WriteAsXml(value interface{}) error {
 		return nil
 	}
 	if PrettyPrintResponses {
-		output, err = xml.MarshalIndent(value, " ", " ")
+		output, err = xml.MarshalIndent(value, "", "  ")
 	} else {
 		output, err = xml.Marshal(value)
 	}

--- a/swagger/swagger_test.go
+++ b/swagger/swagger_test.go
@@ -26,7 +26,7 @@ func TestServiceToApi(t *testing.T) {
 		WebServices:    []*restful.WebService{ws}}
 	sws := newSwaggerService(cfg)
 	decl := sws.composeDeclaration(ws, "/tests")
-	_, err := json.MarshalIndent(decl, " ", " ")
+	_, err := json.MarshalIndent(decl, "", "  ")
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/swagger/utils_test.go
+++ b/swagger/utils_test.go
@@ -26,7 +26,7 @@ func compareJson(t *testing.T, flatCompare bool, value interface{}, expectedJson
 	if flatCompare {
 		output, err = json.Marshal(value)
 	} else {
-		output, err = json.MarshalIndent(value, " ", " ")
+		output, err = json.MarshalIndent(value, "", "  ")
 	}
 	if err != nil {
 		t.Error(err.Error())


### PR DESCRIPTION
@civitaslearning/platform A long-standing annoyance for me... we return incorrectly indented JSON because at the time I added this to go-restful, I didn't understand the correct usage of `json.MarshalIndent`.

As a result, we get back stuff that looks like this:

```
$ curl http://api.private.civitaslearning.com/import/v1/version
{
  "version": "1.0.1.457",
  "service": "import",
  "build": {
   "commit": "99a3f8b49b3a0e50e623b25c6cbaee54dd3761c8 origin/master",
   "build_time": "2016-04-21T22:37:14Z"
  }
 }
$
```

note the final `}` with a space before it.
